### PR TITLE
Support amplicon schemes in artic bed format

### DIFF
--- a/viridian/scheme_simulate.py
+++ b/viridian/scheme_simulate.py
@@ -86,7 +86,7 @@ def simulate_all_schemes(
 
     for scheme_name, scheme_tsv in amplicon_scheme_name_to_tsv.items():
         logging.info(f"Processing scheme {scheme_name}")
-        scheme = scheme_id.Scheme(tsv_file=scheme_tsv)
+        scheme = scheme_id.Scheme(amp_scheme_file=scheme_tsv)
 
         for fragment in False, True:
             if fragment:


### PR DESCRIPTION
If an amplicon scheme filename ends with ".bed" then it assumes it's in "artic bed" format, instead of viridian's usual tsv format.

For example: https://github.com/quick-lab/primerschemes/blob/main/primerschemes/artic-sars-cov-2/400/v5.3.2/primer.bed

Not really advertising this feature for now because there's no proper spec for that bed format (in particular, the naming convention used in column 4), but is requested by @bede.