### PR TITLE
cylon commit 8b61712aaff9a674f497b6569312cd84bfc446b6

### DIFF
--- a/.ci/install_dependencies.sh
+++ b/.ci/install_dependencies.sh
@@ -122,7 +122,7 @@ rm -rf mummer-4.0.0rc1
 cd $install_root
 git clone https://github.com/iqbal-lab-org/cylon.git
 cd cylon
-git checkout 57d559a76254b0b95785f7c02fa58ef806713e01
+git checkout 8b61712aaff9a674f497b6569312cd84bfc446b6
 pip3 install .
 cd ..
 rm -rf cylon


### PR DESCRIPTION
Use new Cylon with fix for mpox, where sometimes minimap2 missed some matches and then amplicons got left out from the start and end of the genome